### PR TITLE
feat(app): org setup prompt, improved org switcher, and consume enric…

### DIFF
--- a/src/components/organization/OrganizationSwitcher.tsx
+++ b/src/components/organization/OrganizationSwitcher.tsx
@@ -1,8 +1,7 @@
-import { useState } from "react";
-import { ChevronsUpDown, Plus } from "lucide-react";
-import { cn } from "../../lib/utils";
+import { useEffect, useMemo, useState } from "react";
+import { Building, ChevronsUpDown, Plus } from "lucide-react";
+import { cn, getInitials } from "../../lib/utils";
 import { Button } from "../ui/button";
-// import { useNavigate } from "react-router-dom";
 import {
   Command,
   CommandEmpty,
@@ -13,11 +12,10 @@ import {
   CommandSeparator,
 } from "../ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
-// import { Badge } from "../ui/badge";
-import { Avatar } from "../ui/avatar";
-// import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
-// import { getInitials } from "../../lib/utils";
+import { Avatar, AvatarFallback } from "../ui/avatar";
 import { useAuth } from "../../store/hooks";
+import { getApiClient, useV2Api } from "../../api/axios";
+import { useToast } from "../../hooks/use-toast";
 
 interface OrganizationSwitcherProps {
   className?: string;
@@ -29,93 +27,62 @@ export default function OrganizationSwitcher({
   onCreateOrganization,
 }: OrganizationSwitcherProps) {
   const [open, setOpen] = useState(false);
-  const { canManageOrganization } = useAuth();
-  // const {
-  //   organizations,
-  //   activeOrganization,
-  //   switchOrganization,
-  //   fetchUserOrganizations,
-  //   isLoading
-  // } = useOrganizationStore();
+  const {
+    canManageOrganization,
+    organization,
+    setActiveOrganization,
+    canCreateTeams,
+  } = useAuth();
+  const { toast } = useToast();
+  const useV2 = useV2Api("organizations");
+  const api = useMemo(() => getApiClient(useV2 ? "v2" : undefined), [useV2]);
+  const [items, setItems] = useState<
+    Array<{ _id: string; name?: string | null; status?: string }>
+  >([]);
+  const [loading, setLoading] = useState(false);
 
-  // Fetch organizations on component mount
-  // useEffect(() => {
-  //   fetchUserOrganizations();
-  // }, [fetchUserOrganizations]);
+  useEffect(() => {
+    let mounted = true;
+    const load = async () => {
+      try {
+        setLoading(true);
+        const res = await api.get("/organizations");
+        const list = (res.data?.organizations || []) as Array<any>;
+        if (mounted) setItems(list);
+      } catch (e: any) {
+        toast.error({
+          title: "Failed to load organizations",
+          description: e?.response?.data?.message || e.message,
+        });
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+    if (open && items.length === 0) load();
+    return () => {
+      mounted = false;
+    };
+  }, [open, api, items.length, toast]);
+  // Hide switcher for inactive orgs or plans without collaboration
+  const shouldShow =
+    !!canCreateTeams &&
+    (organization?.status || "").toLowerCase() !== "inactive";
+  if (!shouldShow) return null;
 
-  // const handleOrganizationSelect = async (organizationId: string) => {
-  //   console.log("Main switcher - Selecting organization:", organizationId);
-  //   // await switchOrganization(organizationId);
-  //   setOpen(false);
-  // };
-
-  // const getRoleBadgeVariant = (role: string) => {
-  //   switch (role) {
-  //     case "owner":
-  //       return "default"; // Blue badge - highest authority
-  //     case "admin":
-  //       return "success"; // Green badge - management role
-  //     case "member":
-  //       return "warning"; // Yellow badge - active contributor
-  //     case "viewer":
-  //       return "outline"; // Subtle badge - read-only access
-  //     default:
-  //       return "outline";
-  //   }
-  // };
-
-  // const getRoleDisplayName = (role: string) => {
-  //   switch (role) {
-  //     case "owner":
-  //       return "Owner";
-  //     case "admin":
-  //       return "Admin";
-  //     case "member":
-  //       return "Member";
-  //     case "viewer":
-  //       return "Viewer";
-  //     default:
-  //       return role;
-  //   }
-  // };
-
-  // if (isLoading && organizations.length === 0) {
-  //   return (
-  //     <div className={cn("flex items-center space-x-2", className)}>
-  //       <div className="h-8 w-8 animate-pulse rounded-full bg-gray-200 dark:bg-gray-800" />
-  //       <div className="h-4 w-32 animate-pulse rounded bg-gray-200 dark:bg-gray-800" />
-  //     </div>
-  //   );
-  // }
-
-  // If no organizations, show create organization prompt (only for org owners)
-  // if (organizations.length === 0) {
-  //   if (canManageOrganization && onCreateOrganization) {
-  //     return (
-  //       <Button
-  //         variant="outline"
-  //         onClick={onCreateOrganization}
-  //         className={cn("justify-start", className)}
-  //       >
-  //         <Plus className="mr-2 h-4 w-4" />
-  //         Create Organization
-  //       </Button>
-  //     );
-  //   }
-
-  //   // For non-org owners with no organizations, show a disabled state
-  //   return (
-  //     <Button
-  //       variant="outline"
-  //       disabled
-  //       className={cn("justify-start opacity-60", className)}
-  //       title="No organizations available"
-  //     >
-  //       <Building className="mr-2 h-4 w-4" />
-  //       No Organizations
-  //     </Button>
-  //   );
-  // }
+  const getRoleDisplayName = (role: string) => {
+    switch (role) {
+      case "owner":
+        return "Owner";
+      case "admin":
+        return "Admin";
+      case "member":
+        return "Member";
+      case "viewer":
+        return "Viewer";
+      default:
+        return role;
+    }
+  };
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -128,26 +95,23 @@ export default function OrganizationSwitcher({
         >
           <div className="flex items-center space-x-2 min-w-0 flex-1">
             <Avatar className="h-6 w-6">
-              {/* <AvatarImage 
-                src={activeOrganization?.logo} 
-                alt={activeOrganization?.name}
-              />
               <AvatarFallback className="text-xs">
-                {activeOrganization?.name 
-                  ? getInitials(activeOrganization.name)
-                  : <Building className="h-3 w-3" />
-                }
-              </AvatarFallback> */}
+                {organization?.name ? (
+                  getInitials(organization.name)
+                ) : (
+                  <Building className="h-3 w-3" />
+                )}
+              </AvatarFallback>
             </Avatar>
             <div className="flex flex-col min-w-0 flex-1">
               <span className="truncate text-sm font-medium">
-                {/* {activeOrganization?.name || 'Select Organization'} */}
+                {organization?.name || "Select Organization"}
               </span>
-              {/* {activeOrganization && (
+              {organization && (
                 <span className="text-xs text-muted-foreground">
-                  {getRoleDisplayName(activeOrganization.userRole)}
+                  {getRoleDisplayName(organization?.role || "member")}
                 </span>
-              )} */}
+              )}
             </div>
           </div>
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
@@ -168,53 +132,44 @@ export default function OrganizationSwitcher({
           </div>
           <CommandList className="max-h-[300px]">
             <CommandEmpty className="py-6 text-center text-sm">
-              No organizations found.
+              {loading ? "Loading organizations..." : "No organizations found."}
             </CommandEmpty>
             <CommandGroup heading="Organizations" className="p-1">
-              {/* {organizations.map((organization) => (
+              {items.map((org) => (
                 <CommandItem
-                  key={organization._id}
-                  value={organization.name}
-                  onSelect={() => handleOrganizationSelect(organization._id)}
+                  key={org._id}
+                  value={org.name || org._id}
+                  onSelect={async () => {
+                    try {
+                      setOpen(false);
+                      await setActiveOrganization({
+                        _id: org._id,
+                        name: org.name || null,
+                        status: org.status || undefined,
+                        role: null,
+                      });
+                    } catch (e: any) {
+                      toast.error({
+                        title: "Failed to switch organization",
+                        description: e?.response?.data?.message || e.message,
+                      });
+                    }
+                  }}
                   className="flex items-center justify-between cursor-pointer px-2 py-3 rounded-sm data-[selected='true']:bg-transparent hover:data-[selected='true']:bg-accent hover:bg-accent hover:text-accent-foreground"
                 >
                   <div className="flex items-center space-x-2 min-w-0 flex-1">
-                    <Avatar className="h-6 w-6">
-                      <AvatarImage 
-                        src={organization.logo} 
-                        alt={organization.name}
-                      />
-                      <AvatarFallback className="text-xs">
-                        {getInitials(organization.name)}
-                      </AvatarFallback>
-                    </Avatar>
+                    <Avatar className="h-6 w-6" />
                     <div className="flex flex-col min-w-0 flex-1">
                       <span className="truncate text-sm font-medium">
-                        {organization.name}
+                        {org.name || "Untitled Organization"}
                       </span>
-                      <div className="flex items-center space-x-2">
-                        <Badge 
-                          variant={getRoleBadgeVariant(organization.userRole)}
-                          className="text-xs"
-                        >
-                          {getRoleDisplayName(organization.userRole)}
-                        </Badge>
-                        <span className="text-xs text-muted-foreground">
-                          {organization.memberCount} member{organization.memberCount !== 1 ? 's' : ''}
-                        </span>
-                      </div>
+                      <span className="text-xs text-muted-foreground">
+                        {org.status || ""}
+                      </span>
                     </div>
                   </div>
-                  <Check
-                    className={cn(
-                      "ml-2 h-4 w-4",
-                      activeOrganization?._id?.toString() === organization._id?.toString()
-                        ? "opacity-100"
-                        : "opacity-0"
-                    )}
-                  />
                 </CommandItem>
-              ))} */}
+              ))}
             </CommandGroup>
             {onCreateOrganization && canManageOrganization && (
               <>
@@ -246,74 +201,65 @@ export function CompactOrganizationSwitcher({
   onCreateOrganization,
 }: OrganizationSwitcherProps) {
   const [open, setOpen] = useState(false);
-  // const navigate = useNavigate();
-  const { canManageOrganization } = useAuth();
-  // const {
-  //   activeOrganization,
-  //   organizations,
-  //   switchOrganization,
-  //   fetchUserOrganizations,
-  // } = useOrganizationStore();
+  const {
+    canManageOrganization,
+    organization,
+    setActiveOrganization,
+    canCreateTeams,
+  } = useAuth();
+  const { toast } = useToast();
+  const useV2 = useV2Api("organizations");
+  const api = useMemo(() => getApiClient(useV2 ? "v2" : undefined), [useV2]);
+  const [items, setItems] = useState<
+    Array<{ _id: string; name?: string | null; status?: string }>
+  >([]);
+  const [loading, setLoading] = useState(false);
 
-  // Fetch organizations on component mount
-  // useEffect(() => {
-  //   fetchUserOrganizations();
-  // }, [fetchUserOrganizations]);
-
-  // const handleOrganizationSelect = async (organizationId: string) => {
-  //   // await switchOrganization(organizationId);
-  //   setOpen(false);
-
-  //   // Navigate to the organization dashboard
-  //   navigate("/dashboard/organizations");
-  // };
-
-  // if (organizations.length === 0) {
-  //   if (canManageOrganization && onCreateOrganization) {
-  //     return (
-  //       <Button
-  //         variant="ghost"
-  //         size="sm"
-  //         onClick={onCreateOrganization}
-  //         className={cn("h-8 px-2", className)}
-  //         title="Create Organization"
-  //       >
-  //         <Plus className="h-4 w-4" />
-  //       </Button>
-  //     );
-  //   }
-
-  //   // For non-org owners with no organizations, show disabled state
-  //   return (
-  //     <Button
-  //       variant="ghost"
-  //       size="sm"
-  //       disabled
-  //       className={cn("h-8 px-2 opacity-60", className)}
-  //       title="No organizations available"
-  //     >
-  //       <Building className="h-4 w-4" />
-  //     </Button>
-  //   );
-  // }
+  useEffect(() => {
+    let mounted = true;
+    const load = async () => {
+      try {
+        setLoading(true);
+        const res = await api.get("/organizations");
+        const list = (res.data?.organizations || []) as Array<any>;
+        if (mounted) setItems(list);
+      } catch (e: any) {
+        toast.error({
+          title: "Failed to load organizations",
+          description: e?.response?.data?.message || e.message,
+        });
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+    if (open && items.length === 0) load();
+    return () => {
+      mounted = false;
+    };
+  }, [open, api, items.length, toast]);
+  // Hide compact switcher for inactive orgs or plans without collaboration
+  const shouldShow =
+    !!canCreateTeams &&
+    (organization?.status || "").toLowerCase() !== "inactive";
+  if (!shouldShow) return null;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button variant="ghost" size="sm" className={cn("h-8 px-2", className)}>
           <Avatar className="h-6 w-6">
-            {/* <AvatarImage
-              src={activeOrganization?.logo}
-              alt={activeOrganization?.name}
-            />
-            <AvatarFallback className="text-xs">
-              {activeOrganization?.name ? (
-                getInitials(activeOrganization.name)
+            {/* <AvatarImage src={organization?.logo} alt={organization?.name} /> */}
+            {/* <AvatarFallback className="text-xs">
+              {organization?.name ? (
+                getInitials(organization.name)
               ) : (
                 <Building className="h-3 w-3" />
               )}
             </AvatarFallback> */}
           </Avatar>
+          <span className="ml-2 text-sm max-w-[120px] truncate">
+            {organization?.name || "Select"}
+          </span>
           <ChevronsUpDown className="ml-2 h-3 w-3 opacity-50" />
         </Button>
       </PopoverTrigger>
@@ -332,41 +278,44 @@ export function CompactOrganizationSwitcher({
           </div>
           <CommandList className="max-h-[300px]">
             <CommandEmpty className="py-6 text-center text-sm">
-              No organizations found.
+              {loading ? "Loading organizations..." : "No organizations found."}
             </CommandEmpty>
             <CommandGroup className="p-1">
-              {/* {organizations.map((organization) => (
+              {items.map((org) => (
                 <CommandItem
-                  key={organization._id}
-                  value={organization.name}
-                  onSelect={() => handleOrganizationSelect(organization._id)}
+                  key={org._id}
+                  value={org.name || org._id}
+                  onSelect={async () => {
+                    try {
+                      setOpen(false);
+                      await setActiveOrganization({
+                        _id: org._id,
+                        name: org.name || null,
+                        status: org.status || undefined,
+                        role: null,
+                      });
+                    } catch (e: any) {
+                      toast.error({
+                        title: "Failed to switch organization",
+                        description: e?.response?.data?.message || e.message,
+                      });
+                    }
+                  }}
                   className="flex items-center justify-between cursor-pointer px-2 py-2 rounded-sm data-[selected='true']:bg-transparent hover:data-[selected='true']:bg-accent hover:bg-accent hover:text-accent-foreground"
                 >
                   <div className="flex items-center space-x-3">
-                    <Avatar className="h-6 w-6">
-                      <AvatarImage 
-                        src={organization.logo} 
-                        alt={organization.name}
-                      />
-                      <AvatarFallback className="text-xs bg-primary/10">
-                        {getInitials(organization.name)}
-                      </AvatarFallback>
-                    </Avatar>
+                    <Avatar className="h-6 w-6" />
                     <div className="flex flex-col">
-                      <span className="text-sm font-medium">{organization.name}</span>
-                      <span className="text-xs text-muted-foreground">{organization.userRole}</span>
+                      <span className="text-sm font-medium">
+                        {org.name || "Untitled Organization"}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        {org.status || ""}
+                      </span>
                     </div>
                   </div>
-                  <Check
-                    className={cn(
-                      "h-4 w-4",
-                      activeOrganization?._id?.toString() === organization._id?.toString()
-                        ? "opacity-100"
-                        : "opacity-0"
-                    )}
-                  />
                 </CommandItem>
-              ))} */}
+              ))}
             </CommandGroup>
             {onCreateOrganization && canManageOrganization && (
               <>

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -17,6 +17,7 @@ export const useAuth = () => {
     clearError: clearAuthError,
     updateSubscriptionInfo,
     refreshPermissions,
+    setActiveOrganization,
 
     // Enhanced authentication context
     userRole,
@@ -89,6 +90,7 @@ export const useAuth = () => {
     clearAuthError,
     updateSubscriptionInfo,
     refreshPermissions,
+    setActiveOrganization,
 
     // Computed permissions
     isAdmin,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,9 @@ export interface Organization {
   _id: string;
   name: string;
   description?: string;
+  role?: "owner" | "admin" | "member" | "viewer";
+  logo?: string;
+  status: "active" | "inactive" | "suspended";
   type: "enterprise" | "business" | "startup";
   settings: {
     permissions: string[];
@@ -52,7 +55,14 @@ export interface User {
   stripeCustomerId?: string;
   subscriptionId?: string;
   subscriptionStatus?: "paid" | "trialing" | "cancelled" | "inactive";
-  subscriptionTier?: "free" | "creator" | "team" | "enterprise" | "trial" | "basic" | "business";
+  subscriptionTier?:
+    | "free"
+    | "creator"
+    | "team"
+    | "enterprise"
+    | "trial"
+    | "basic"
+    | "business";
   subscriptionRenewalDate?: string;
   invoices?: any[];
   renewalDate?: string;


### PR DESCRIPTION
…hed org info

- DashboardHeader: inline 'Set up your organization' prompt
  - Shown only when: owner + missing org name + plan supports teams
  - Saves via PATCH /organizations/:id/profile and refreshes auth state
  - Dismiss option; toasts for success/failure
- Organization switcher (full + compact):
  - Fetch orgs on open (GET /organizations)
  - Show org name/status; click to switch context via setActiveOrganization
  - Hide switcher when plan does not allow teams or org is inactive
  - Fix hook-order bug by moving early returns after hooks
- Auth store:
  - Add setActiveOrganization action: updates active org + refreshes permissions
  - Consume enriched org summary from V2 login/me (name/status/role)
  - Keep x-organization-id header in axios v2 aligned with active org

Files (highlights)
- src/layouts/DashboardHeader.tsx: setup banner + guarded visibility by canCreateTeams
- src/components/organization/OrganizationSwitcher.tsx: fetch/select/hide logic + hook-order fix
- src/store/authStore.ts: setActiveOrganization + adapt V2 org summary
- src/store/hooks.ts: expose setActiveOrganization
- src/api/axios.ts: x-organization-id already injected, leveraged by new flows

UX impact
- Collaboration plans (Trial/Team/Enterprise): smooth org setup + easy switching
- Creator/Free or inactive orgs: no collaboration UI
- Eliminates extra fetch for org name in header (consumes enriched auth responses).