### PR TITLE
chore: no app changes for Instagram/YouTube GET /connect parity

### DIFF
--- a/src/api/invitations.ts
+++ b/src/api/invitations.ts
@@ -1,67 +1,95 @@
-import axiosInstance from './axios';
+import axiosInstance from "./axios";
+
+// Backend-aligned DTOs (skedlii-api-v2 Invitations module)
+export type OrgRole = "owner" | "admin" | "editor" | "viewer";
 
 export interface SendInvitationRequest {
   email: string;
-  firstName: string;
-  lastName: string;
-  role: string;
-  organizationId: string;
-  teamIds?: string[];
+  orgId: string;
+  role: OrgRole;
+  expiresInMinutes?: number; // optional; backend default exists
 }
 
 export interface SendInvitationResponse {
-  uid: string;
-  email: string;
-  firstName: string;
-  lastName: string;
-  role: string;
-  organizationId: string;
-  teamIds: string[];
-  userExists: boolean;
-  organizationName: string;
-  settings: {
-    permissions: string[];
-    theme: string;
-    notifications: string[];
-  };
-  createdAt: string;
-  updatedAt: string;
+  invitationId: string;
+  token?: string; // non-prod convenience
 }
 
 export interface VerifyInvitationResponse {
   email: string;
-  firstName: string;
-  lastName: string;
-  organizationName: string;
-  role: string;
-  userExists: boolean;
-  expiresAt: string;
-  emailMismatch: boolean;
+  orgId: string;
+  role: OrgRole;
+  expiresAt?: string;
 }
 
 export interface ResendInvitationResponse {
-  message: string;
+  invitationId: string;
+  token?: string;
+}
+
+export interface InvitationListItem {
+  _id: string;
+  orgId: string;
+  email: string;
+  role: OrgRole;
+  status: 'pending' | 'accepted' | 'expired' | 'revoked';
+  invitedBy?: string;
+  createdAt?: string;
+  expiresAt?: string;
 }
 
 export const invitationsApi = {
-  sendInvitation: async (data: SendInvitationRequest): Promise<SendInvitationResponse> => {
-    const response = await axiosInstance.post<SendInvitationResponse>('/invitations', data);
+  // POST /invitations { email, orgId, role, expiresInMinutes? }
+  sendInvitation: async (
+    data: SendInvitationRequest
+  ): Promise<SendInvitationResponse> => {
+    const response = await axiosInstance.post<SendInvitationResponse>(
+      "/invitations",
+      data
+    );
     return response.data;
   },
 
-  verifyInvitation: async (token: string): Promise<VerifyInvitationResponse> => {
-    const response = await axiosInstance.get<VerifyInvitationResponse>(`/invitations/${token}/verify`);
+  // GET /invitations/:token/verify → { email, orgId, role, expiresAt }
+  verifyInvitation: async (
+    token: string
+  ): Promise<VerifyInvitationResponse> => {
+    const response = await axiosInstance.get<VerifyInvitationResponse>(
+      `/invitations/${token}/verify`
+    );
     return response.data;
   },
 
-  acceptInvitation: async (token: string, password?: string): Promise<{ email: string }> => {
-    const body = password ? { password } : {};
-    const response = await axiosInstance.post<{ email: string }>(`/invitations/${token}/accept`, body);
+  // POST /invitations/:token/accept (JWT required) → 204
+  acceptInvitation: async (token: string): Promise<void> => {
+    await axiosInstance.post<void>(`/invitations/${token}/accept`, {});
+  },
+
+  // POST /invitations/resend { invitationId }
+  resendInvitation: async (
+    invitationId: string
+  ): Promise<ResendInvitationResponse> => {
+    const response = await axiosInstance.post<ResendInvitationResponse>(
+      "/invitations/resend",
+      { invitationId }
+    );
     return response.data;
   },
 
-  resendInvitation: async (email: string): Promise<ResendInvitationResponse> => {
-    const response = await axiosInstance.post<ResendInvitationResponse>('/invitations/resend', { email });
-    return response.data;
+  // GET /invitations?orgId=...&status=pending
+  listInvitations: async (
+    orgId: string,
+    status: 'pending' | 'accepted' | 'expired' | 'revoked' = 'pending'
+  ): Promise<InvitationListItem[]> => {
+    const response = await axiosInstance.get<{ items: InvitationListItem[] }>(
+      `/invitations`,
+      { params: { orgId, status } }
+    );
+    return response.data.items;
+  },
+
+  // DELETE /invitations/:id
+  revokeInvitation: async (invitationId: string): Promise<void> => {
+    await axiosInstance.delete(`/invitations/${invitationId}`);
   },
 };

--- a/src/api/socialApi/index.ts
+++ b/src/api/socialApi/index.ts
@@ -19,7 +19,9 @@ export const socialApi = {
   // Get organization social accounts
   getOrganizationSocialAccounts: async (organizationId: string) => {
     try {
-      const response = await axiosInstance.get(`/social-accounts/organization/${organizationId}`);
+      const response = await axiosInstance.get(
+        `/social-accounts/organization/${organizationId}`
+      );
       return response.data;
     } catch (error: any) {
       console.error("Failed to fetch organization social accounts:", error);
@@ -72,7 +74,7 @@ export const socialApi = {
   connectThreads: async () => {
     const response = await apiRequest(
       "GET",
-      `/social-accounts/threads/direct-auth`
+      `/social-accounts/threads/connect`
     );
     return response;
   },
@@ -80,7 +82,7 @@ export const socialApi = {
   connectLinkedIn: async () => {
     const response = await apiRequest(
       "GET",
-      `/social-accounts/linkedin/direct-auth`
+      `/social-accounts/linkedin/connect`
     );
     return response;
   },
@@ -88,7 +90,7 @@ export const socialApi = {
   connectFacebook: async () => {
     const response = await apiRequest(
       "GET",
-      `/social-accounts/facebook/direct-auth`
+      `/social-accounts/facebook/connect`
     );
     return response;
   },
@@ -100,7 +102,7 @@ export const socialApi = {
   }) => {
     const response = await apiRequest(
       "GET",
-      `/social-accounts/meta/direct-auth?platform=${platform}`
+      `/social-accounts/meta/connect?platform=${platform}`
     );
     return response;
   },
@@ -108,7 +110,7 @@ export const socialApi = {
   connectInstagram: async () => {
     const response = await apiRequest(
       "GET",
-      `/social-accounts/instagram/direct-auth`
+      `/social-accounts/instagram/connect`
     );
     return response;
   },
@@ -116,7 +118,7 @@ export const socialApi = {
   connectTikTok: async () => {
     const response = await apiRequest(
       "GET",
-      `/social-accounts/tiktok/direct-auth`
+      `/social-accounts/tiktok/connect`
     );
     return response;
   },
@@ -124,7 +126,7 @@ export const socialApi = {
   connectYoutube: async () => {
     const response = await apiRequest(
       "GET",
-      `/social-accounts/youtube/direct-auth`
+      `/social-accounts/youtube/connect`
     );
     return response;
   },
@@ -180,7 +182,7 @@ export const socialApi = {
   refreshYoutubeAccessToken: async ({ accountId }: { accountId: string }) => {
     try {
       const response = await axiosInstance.get(
-        `/social-accounts/youtube/refresh/${accountId}`
+        `/social-accounts/youtube/reauth/start/${accountId}`
       );
       return response.data;
     } catch (error: any) {

--- a/src/components/organization/OrganizationSwitcher.tsx
+++ b/src/components/organization/OrganizationSwitcher.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Building, ChevronsUpDown, Plus } from "lucide-react";
 import { cn, getInitials } from "../../lib/utils";
 import { Button } from "../ui/button";
@@ -27,6 +28,7 @@ export default function OrganizationSwitcher({
   onCreateOrganization,
 }: OrganizationSwitcherProps) {
   const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
   const {
     canManageOrganization,
     organization,
@@ -148,6 +150,8 @@ export default function OrganizationSwitcher({
                         status: org.status || undefined,
                         role: null,
                       });
+                      // Route to organization dashboard after switching
+                      navigate("/dashboard/organizations");
                     } catch (e: any) {
                       toast.error({
                         title: "Failed to switch organization",
@@ -201,6 +205,7 @@ export function CompactOrganizationSwitcher({
   onCreateOrganization,
 }: OrganizationSwitcherProps) {
   const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
   const {
     canManageOrganization,
     organization,
@@ -294,6 +299,8 @@ export function CompactOrganizationSwitcher({
                         status: org.status || undefined,
                         role: null,
                       });
+                      // Route to organization dashboard after switching
+                      navigate("/dashboard/organizations");
                     } catch (e: any) {
                       toast.error({
                         title: "Failed to switch organization",

--- a/src/components/social-accounts/index.tsx
+++ b/src/components/social-accounts/index.tsx
@@ -44,7 +44,7 @@ import {
   TrendingUp,
   Eye,
   Calendar,
-  Zap,
+  // Zap,
 } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -216,22 +216,24 @@ export default function SocialAccounts() {
 
   // Individual user accounts (only when not using organization accounts)
   const {
-    data: individualAccounts = [],
+    data: individualAccountsData,
     isPending: isIndividualAccountsLoading,
     refetch: refetchIndividualAccounts,
   } = useGetSocialAccounts(shouldUseOrganizationAccounts ? "" : user?._id);
+  const individualAccounts: any[] = individualAccountsData?.items ?? [];
 
   // Organization accounts (only when using organization accounts)
   const {
-    data: organizationAccounts = [],
+    data: organizationAccountsData,
     isPending: isOrganizationAccountsLoading,
     refetch: refetchOrganizationAccounts,
   } = useGetOrganizationSocialAccounts(
     shouldUseOrganizationAccounts ? organization?._id || "" : ""
   );
+  const organizationAccounts: any[] = organizationAccountsData?.items ?? [];
 
   // Use the appropriate accounts and loading state
-  const accounts = shouldUseOrganizationAccounts
+  const accounts: any[] = shouldUseOrganizationAccounts
     ? organizationAccounts
     : individualAccounts;
   const isAccountsLoading = shouldUseOrganizationAccounts
@@ -242,93 +244,99 @@ export default function SocialAccounts() {
     : refetchIndividualAccounts;
 
   // Fetch organization teams for assignment functionality
-  const { data: organizationTeams = [] } = useQuery<Team[]>({
-    queryKey: ["/teams", organization?._id],
-    queryFn: () => {
-      if (!organization) return Promise.resolve([]);
-      return teamsApi.getTeams(organization._id);
-    },
-    enabled: Boolean(shouldUseOrganizationAccounts && organization),
-  });
+  // const { data: organizationTeams = [] } = useQuery<Team[]>({
+  //   queryKey: ["/teams", organization?._id],
+  //   queryFn: () => {
+  //     if (!organization) return Promise.resolve([]);
+  //     return teamsApi.getTeams(organization._id);
+  //   },
+  //   enabled: Boolean(shouldUseOrganizationAccounts && organization),
+  // });
+
+  console.log({ accounts });
 
   // Team assignment mutations
-  const { mutate: assignToTeam, isPending: isAssigning } = useMutation({
-    mutationFn: async ({
-      teamId,
-      accountId,
-    }: {
-      teamId: string;
-      accountId: string;
-    }) => {
-      if (!organization) throw new Error("No active organization");
-      return await teamsApi.assignSocialAccountToTeam(
-        organization._id,
-        teamId,
-        accountId
-      );
-    },
-    onSuccess: () => {
-      // Invalidate both social accounts and teams queries to refresh data
-      if (shouldUseOrganizationAccounts) {
-        queryClient.invalidateQueries({ queryKey: ["/social-accounts/organization", organization?._id] });
-      } else {
-        queryClient.invalidateQueries({ queryKey: ["/social-accounts"] });
-      }
-      queryClient.invalidateQueries({ queryKey: ["/teams"] });
-      toast({
-        title: "Account assigned",
-        description:
-          "Social account has been successfully assigned to the team.",
-      });
-    },
-    onError: (error: any) => {
-      toast({
-        title: "Assignment failed",
-        description:
-          error.response?.data?.message || "Failed to assign account to team.",
-        variant: "destructive",
-      });
-    },
-  });
+  // const { mutate: assignToTeam, isPending: isAssigning } = useMutation({
+  //   mutationFn: async ({
+  //     teamId,
+  //     accountId,
+  //   }: {
+  //     teamId: string;
+  //     accountId: string;
+  //   }) => {
+  //     if (!organization) throw new Error("No active organization");
+  //     return await teamsApi.assignSocialAccountToTeam(
+  //       organization._id,
+  //       teamId,
+  //       accountId
+  //     );
+  //   },
+  //   onSuccess: () => {
+  //     // Invalidate both social accounts and teams queries to refresh data
+  //     if (shouldUseOrganizationAccounts) {
+  //       queryClient.invalidateQueries({
+  //         queryKey: ["/social-accounts/organization", organization?._id],
+  //       });
+  //     } else {
+  //       queryClient.invalidateQueries({ queryKey: ["/social-accounts"] });
+  //     }
+  //     queryClient.invalidateQueries({ queryKey: ["/teams"] });
+  //     toast({
+  //       title: "Account assigned",
+  //       description:
+  //         "Social account has been successfully assigned to the team.",
+  //     });
+  //   },
+  //   onError: (error: any) => {
+  //     toast({
+  //       title: "Assignment failed",
+  //       description:
+  //         error.response?.data?.message || "Failed to assign account to team.",
+  //       variant: "destructive",
+  //     });
+  //   },
+  // });
 
-  const { mutate: unassignFromTeam, isPending: isUnassigning } = useMutation({
-    mutationFn: async ({
-      teamId,
-      accountId,
-    }: {
-      teamId: string;
-      accountId: string;
-    }) => {
-      if (!organization) throw new Error("No active organization");
-      return await teamsApi.removeSocialAccountFromTeam(
-        organization._id,
-        teamId,
-        accountId
-      );
-    },
-    onSuccess: () => {
-      // Invalidate both social accounts and teams queries to refresh data
-      if (shouldUseOrganizationAccounts) {
-        queryClient.invalidateQueries({ queryKey: ["/social-accounts/organization", organization?._id] });
-      } else {
-        queryClient.invalidateQueries({ queryKey: ["/social-accounts"] });
-      }
-      queryClient.invalidateQueries({ queryKey: ["/teams"] });
-      toast({
-        title: "Account unassigned",
-        description: "Social account has been removed from the team.",
-      });
-    },
-    onError: (error: any) => {
-      toast({
-        title: "Unassignment failed",
-        description:
-          error.response?.data?.message ||
-          "Failed to remove account from team.",
-        variant: "destructive",
-      });
-    },
-  });
+  // const { mutate: unassignFromTeam, isPending: isUnassigning } = useMutation({
+  //   mutationFn: async ({
+  //     teamId,
+  //     accountId,
+  //   }: {
+  //     teamId: string;
+  //     accountId: string;
+  //   }) => {
+  //     if (!organization) throw new Error("No active organization");
+  //     return await teamsApi.removeSocialAccountFromTeam(
+  //       organization._id,
+  //       teamId,
+  //       accountId
+  //     );
+  //   },
+  //   onSuccess: () => {
+  //     // Invalidate both social accounts and teams queries to refresh data
+  //     if (shouldUseOrganizationAccounts) {
+  //       queryClient.invalidateQueries({
+  //         queryKey: ["/social-accounts/organization", organization?._id],
+  //       });
+  //     } else {
+  //       queryClient.invalidateQueries({ queryKey: ["/social-accounts"] });
+  //     }
+  //     queryClient.invalidateQueries({ queryKey: ["/teams"] });
+  //     toast({
+  //       title: "Account unassigned",
+  //       description: "Social account has been removed from the team.",
+  //     });
+  //   },
+  //   onError: (error: any) => {
+  //     toast({
+  //       title: "Unassignment failed",
+  //       description:
+  //         error.response?.data?.message ||
+  //         "Failed to remove account from team.",
+  //       variant: "destructive",
+  //     });
+  //   },
+  // });
 
   // Get unique platforms and their counts
   const platformStats = useMemo(() => {
@@ -495,7 +503,7 @@ export default function SocialAccounts() {
         });
         break;
       case "youtube":
-        refreshYoutubeAccessToken(account._id, {
+        refreshYoutubeAccessToken(account.accountId, {
           onSuccess: () => {
             refetchAccounts();
           },
@@ -512,6 +520,8 @@ export default function SocialAccounts() {
         break;
     }
   };
+
+  // console.log({ platformStats });
 
   const togglePlatformFilter = (platform: string) => {
     setSelectedPlatforms((prev) =>
@@ -576,7 +586,7 @@ export default function SocialAccounts() {
           </div>
 
           {/* Enhanced Platform Filter Pills */}
-          {platformStats.uniquePlatforms.length > 1 && (
+          {platformStats?.uniquePlatforms?.length > 1 && (
             <div className="relative overflow-hidden rounded-lg bg-gradient-to-r from-muted/30 via-muted/20 to-muted/30 p-4 border border-border/50 backdrop-blur-sm">
               <div className="absolute inset-0 bg-gradient-to-r from-primary/5 to-purple-500/5" />
               <div className="relative flex flex-wrap items-center gap-3">
@@ -588,7 +598,7 @@ export default function SocialAccounts() {
                 </div>
 
                 <div className="flex flex-wrap gap-2">
-                  {platformStats.uniquePlatforms.map((platform) => {
+                  {platformStats?.uniquePlatforms?.map((platform) => {
                     const isSelected = selectedPlatforms.includes(platform);
                     return (
                       <Button
@@ -669,10 +679,6 @@ export default function SocialAccounts() {
                                 alt={`${account.accountName} profile`}
                                 className="h-12 w-12 rounded-full object-cover ring-2 ring-offset-2 ring-offset-background transition-all duration-200 group-hover:ring-primary/50"
                               />
-                              {/* Platform icon overlay */}
-                              {/* <div className={`absolute -bottom-1 -right-1 p-1 rounded-full ${getClassName(account.platform)} ring-2 ring-background`}>
-                                <i className={`${getSocialIcon(account.platform)} text-xs ${getTextColor(account.platform)}`} />
-                              </div> */}
                             </div>
                           ) : (
                             <div
@@ -685,11 +691,6 @@ export default function SocialAccounts() {
                                   account.platform
                                 )} text-xl ${getTextColor(account.platform)}`}
                               />
-
-                              {/* Pulse effect for active accounts */}
-                              {/* {account.status === 'active' && (
-                                <div className="absolute -inset-1 rounded-xl bg-green-500/20 animate-pulse" />
-                              )} */}
                             </div>
                           )}
 
@@ -710,11 +711,6 @@ export default function SocialAccounts() {
                             <CardTitle className="text-base font-semibold truncate group-hover:text-primary transition-colors">
                               {account.accountName ?? "Unknown Account"}
                             </CardTitle>
-                            {account.status === "active" && (
-                              <div className="flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-green-500/10 border border-green-500/20">
-                                <Zap className="h-2.5 w-2.5 text-green-500" />
-                              </div>
-                            )}
                           </div>
                           <div className="flex items-center gap-2 mt-0.5">
                             <CardDescription className="capitalize font-medium">
@@ -877,10 +873,10 @@ export default function SocialAccounts() {
                   </CardContent>
                   <CardFooter className="relative flex flex-col gap-3 pt-3 border-t border-border/50">
                     {/* Team Assignment (Organization Mode Only) */}
-                    {shouldUseOrganizationAccounts && canCreateTeams && (
+                    {/* {shouldUseOrganizationAccounts && canCreateTeams && (
                       <TeamAssignmentDropdown
                         currentTeamId={account.teamId}
-                        availableTeams={organizationTeams}
+                        availableTeams={organizationTeams || []}
                         onAssign={(teamId) =>
                           assignToTeam({ teamId, accountId: account._id })
                         }
@@ -892,7 +888,7 @@ export default function SocialAccounts() {
                         }
                         isLoading={isAssigning || isUnassigning}
                       />
-                    )}
+                    )} */}
 
                     <div className="flex justify-between items-center">
                       {/* Quick Actions */}
@@ -998,7 +994,7 @@ export default function SocialAccounts() {
 
   return (
     <div className="space-y-6">
-      {accounts.length === 0 && !isLoading ? (
+      {accounts?.length === 0 && !isLoading ? (
         <div className="flex flex-col items-center justify-center space-y-4 h-[60vh]">
           <div className="relative">
             <div className="absolute -inset-4 bg-gradient-to-r from-primary/20 to-purple-500/20 rounded-full blur-lg animate-pulse" />
@@ -1058,7 +1054,7 @@ export default function SocialAccounts() {
                   <div className="flex items-center gap-1 px-2 py-1 rounded-full bg-green-500/10 border border-green-500/20">
                     <Activity className="h-3 w-3 text-green-500 animate-pulse" />
                     <span className="text-xs font-medium text-green-600">
-                      {accounts.length} Active
+                      {accounts?.length} Active
                     </span>
                   </div>
                 </div>
@@ -1089,10 +1085,10 @@ export default function SocialAccounts() {
                 <div className="flex items-center gap-4 pt-2">
                   <div className="flex items-center gap-2 text-sm">
                     <Users className="h-4 w-4 text-primary" />
-                    <span className="font-medium">{accounts.length}</span>
+                    <span className="font-medium">{accounts?.length}</span>
                     <span className="text-muted-foreground">Connected</span>
                   </div>
-                  <div className="flex items-center gap-2 text-sm">
+                  {/* <div className="flex items-center gap-2 text-sm">
                     <BarChart3 className="h-4 w-4 text-green-500" />
                     <span className="font-medium">
                       {
@@ -1101,8 +1097,8 @@ export default function SocialAccounts() {
                       }
                     </span>
                     <span className="text-muted-foreground">Active</span>
-                  </div>
-                  <div className="flex items-center gap-2 text-sm">
+                  </div> */}
+                  {/* <div className="flex items-center gap-2 text-sm">
                     <AlertCircle className="h-4 w-4 text-orange-500" />
                     <span className="font-medium">
                       {
@@ -1113,7 +1109,7 @@ export default function SocialAccounts() {
                     <span className="text-muted-foreground">
                       Need Attention
                     </span>
-                  </div>
+                  </div> */}
                 </div>
               </div>
               {canConnectSocialAccounts ? (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -101,10 +101,12 @@ export function getTextColor(platform: string) {
   }
 }
 
-// Count accounts by platform
-export const platformCounts = (accounts: any[]) => {
-  return accounts.reduce((acc, account) => {
-    const platform = account.platform.toLowerCase();
+// Count accounts by platform (guards undefined and missing platform)
+export const platformCounts = (accounts: any[] | undefined | null) => {
+  const list = Array.isArray(accounts) ? accounts : [];
+  return list.reduce((acc, account) => {
+    const platform = String(account?.platform || "").toLowerCase();
+    if (!platform) return acc;
     acc[platform] = (acc[platform] ?? 0) + 1;
     return acc;
   }, {} as Record<string, number>);
@@ -130,15 +132,16 @@ export const handleSchedulingChange = (
 
 // Helper to count selected accounts per platform
 export const countSelectedByPlatform = (
-  accounts: any[],
+  accounts: any[] | undefined | null,
   selectedAccounts: string[]
 ) => {
-  return accounts
+  const list = Array.isArray(accounts) ? accounts : [];
+  return list
     .filter((account) => selectedAccounts.includes(account._id))
     .reduce((acc, account) => {
-      const platform = account.platform.toLowerCase();
+      const platform = String(account?.platform || "").toLowerCase();
+      if (!platform) return acc;
       acc[platform] = (acc[platform] ?? 0) + 1;
       return acc;
     }, {} as Record<string, number>);
 };
-

--- a/src/pages/AcceptInvitation.tsx
+++ b/src/pages/AcceptInvitation.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import {
@@ -17,6 +17,7 @@ import { invitationsApi, VerifyInvitationResponse } from "../api/invitations";
 import { useToast } from "../hooks/use-toast";
 import { useAuth } from "../store/hooks";
 import { useQueryClient } from '@tanstack/react-query';
+// import { organizationsApi } from "../api/organizations"; // optional fetch for org name if needed later
 
 const AcceptInvitation: React.FC = () => {
   const [searchParams] = useSearchParams();
@@ -24,9 +25,6 @@ const AcceptInvitation: React.FC = () => {
   const { toast } = useToast();
   const { user, authLoading, fetchUserData } = useAuth();
   const queryClient = useQueryClient();
-  const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const [passwordErrors, setPasswordErrors] = useState<string[]>([]);
 
   const token = searchParams.get("token");
   const isLoggedIn = !!user;
@@ -45,8 +43,7 @@ const AcceptInvitation: React.FC = () => {
 
   // Accept invitation mutation
   const acceptMutation = useMutation({
-    mutationFn: (data: { token: string; password?: string }) =>
-      invitationsApi.acceptInvitation(data.token, data.password),
+    mutationFn: (data: { token: string }) => invitationsApi.acceptInvitation(data.token),
     onSuccess: async () => {
       // Different handling based on whether user is logged in and if they already exist
       if (isLoggedIn) {
@@ -63,7 +60,7 @@ const AcceptInvitation: React.FC = () => {
           
           toast.success({
             title: "Successfully Joined Organization!",
-            description: `You've been added to ${invitation?.organizationName}. You can now access this organization from your dashboard.`,
+            description: `You've been added to the organization. You can now access it from your dashboard.`,
           });
 
           // Redirect to dashboard with a short delay
@@ -74,7 +71,7 @@ const AcceptInvitation: React.FC = () => {
           // Still show success but with a note about refreshing
           toast.success({
             title: "Successfully Joined Organization!",
-            description: `You've been added to ${invitation?.organizationName}. Please refresh the page to see the new organization.`,
+            description: `You've been added to the organization. Please refresh if you don't see it yet.`,
           });
           
           setTimeout(() => {
@@ -82,18 +79,12 @@ const AcceptInvitation: React.FC = () => {
           }, 2000);
         }
       } else {
-        // User is not logged in
-        toast.success({
-          title: "Invitation Accepted!",
-          description: invitation?.userExists
-            ? `You've been added to ${invitation.organizationName}. Please log in to access this organization.`
-            : "Your account has been created successfully. You can now log in.",
+        // Not logged in: direct user to login to accept
+        toast.info({
+          title: "Login Required",
+          description: "Please log in with the invited email to accept the invitation.",
         });
-
-        // Redirect to login page
-        setTimeout(() => {
-          navigate("/login");
-        }, 2000);
+        navigate("/login");
       }
     },
     onError: (error: any) => {
@@ -104,27 +95,9 @@ const AcceptInvitation: React.FC = () => {
     },
   });
 
-  // Validate password
-  const validatePassword = (pwd: string): string[] => {
-    const errors: string[] = [];
-    if (pwd.length < 8)
-      errors.push("Password must be at least 8 characters long");
-    if (!/[A-Z]/.test(pwd))
-      errors.push("Password must contain at least one uppercase letter");
-    if (!/[a-z]/.test(pwd))
-      errors.push("Password must contain at least one lowercase letter");
-    if (!/[0-9]/.test(pwd))
-      errors.push("Password must contain at least one number");
-    if (!/[!@#$%^&*(),.?":{}|<>]/.test(pwd))
-      errors.push("Password must contain at least one special character");
-    return errors;
-  };
-
-  // Handle password change
-  const handlePasswordChange = (value: string) => {
-    setPassword(value);
-    setPasswordErrors(validatePassword(value));
-  };
+  const invitedEmail = invitation?.email?.toLowerCase();
+  const loggedInEmail = user?.email?.toLowerCase();
+  const emailMismatch = Boolean(isLoggedIn && invitedEmail && loggedInEmail && invitedEmail !== loggedInEmail);
 
   // Handle form submission
   const handleSubmit = (e: React.FormEvent) => {
@@ -133,43 +106,19 @@ const AcceptInvitation: React.FC = () => {
     if (!token) return;
 
     // Prevent submission if there's an email mismatch
-    if (invitation?.emailMismatch) {
+    if (emailMismatch) {
       toast.warning({
         title: "Email Mismatch",
         description: "Please log out and use the correct account for this invitation.",
       });
       return;
     }
-
-    // Determine if password is needed:
-    // - If user is logged in, no password needed (they're joining a new org)
-    // - If user is not logged in and invitation is for existing user, no password needed
-    // - If user is not logged in and invitation is for new user, password is required
-    const needsPassword = !isLoggedIn && !invitation?.userExists;
-
-    // For new users (not logged in), validate password
-    if (needsPassword) {
-      if (passwordErrors.length > 0) {
-        toast.error({
-          title: "Invalid Password",
-          description: "Please fix the password requirements.",
-        });
-        return;
-      }
-
-      if (password !== confirmPassword) {
-        toast.error({
-          title: "Passwords Do Not Match",
-          description: "Please make sure both passwords are identical.",
-        });
-        return;
-      }
+    if (!isLoggedIn) {
+      navigate("/login");
+      return;
     }
 
-    acceptMutation.mutate({
-      token,
-      password: needsPassword ? password : undefined,
-    });
+    acceptMutation.mutate({ token });
   };
 
   // Loading state (auth or invitation verification)
@@ -220,10 +169,8 @@ const AcceptInvitation: React.FC = () => {
             <CardTitle>Invitation Accepted!</CardTitle>
             <CardDescription>
               {isLoggedIn
-                ? `You've been added to ${invitation.organizationName}`
-                : invitation.userExists
-                ? `You've been added to ${invitation.organizationName}`
-                : "Your account has been created successfully"}
+                ? "You've been added to the organization"
+                : "Login required to finish acceptance"}
             </CardDescription>
           </CardHeader>
           <CardContent className="text-center">
@@ -241,11 +188,9 @@ const AcceptInvitation: React.FC = () => {
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          <CardTitle>Join {invitation.organizationName}</CardTitle>
+          <CardTitle>Join Organization</CardTitle>
           <CardDescription>
-            You've been invited to join{" "}
-            <strong>{invitation.organizationName}</strong> as a{" "}
-            <strong>{invitation.role}</strong>
+            You've been invited to join as a <strong>{invitation.role}</strong>
           </CardDescription>
         </CardHeader>
 
@@ -256,14 +201,7 @@ const AcceptInvitation: React.FC = () => {
               <Input value={invitation.email} disabled className="mt-1" />
             </div>
 
-            <div>
-              <Label className="text-sm font-medium text-gray-700">Name</Label>
-              <Input
-                value={`${invitation.firstName} ${invitation.lastName}`}
-                disabled
-                className="mt-1"
-              />
-            </div>
+            {/* No name data from verify; keep minimal details */}
           </div>
 
           {isLoggedIn ? (
@@ -271,100 +209,33 @@ const AcceptInvitation: React.FC = () => {
               <AlertCircle className="h-4 w-4" />
               <AlertDescription>
                 You are currently logged in as {user?.email}. Accepting this
-                invitation will add you to {invitation.organizationName}.
-              </AlertDescription>
-            </Alert>
-          ) : invitation.emailMismatch ? (
-            <Alert className="mb-6" variant="destructive">
-              <AlertCircle className="h-4 w-4" />
-              <AlertDescription>
-                This invitation is for a different account. Please log out and try again with the correct account.
-              </AlertDescription>
-            </Alert>
-          ) : invitation.userExists ? (
-            <Alert className="mb-6">
-              <AlertCircle className="h-4 w-4" />
-              <AlertDescription>
-                You already have an account. Accepting this invitation will add
-                you to {invitation.organizationName}. You'll need to log in
-                afterwards.
+                invitation will add you to the organization.
               </AlertDescription>
             </Alert>
           ) : (
-            <div className="space-y-4 mb-6">
-              <Alert>
-                <AlertCircle className="h-4 w-4" />
-                <AlertDescription>
-                  This will create a new account for you. Please set a secure
-                  password.
-                </AlertDescription>
-              </Alert>
-
-              <div>
-                <Label htmlFor="password">Password</Label>
-                <Input
-                  id="password"
-                  type="password"
-                  value={password}
-                  onChange={(e) => handlePasswordChange(e.target.value)}
-                  className="mt-1"
-                  placeholder="Enter a secure password"
-                />
-                {passwordErrors.length > 0 && (
-                  <div className="mt-2 space-y-1">
-                    {passwordErrors.map((error, index) => (
-                      <p key={index} className="text-sm text-red-600">
-                        {error}
-                      </p>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              <div>
-                <Label htmlFor="confirmPassword">Confirm Password</Label>
-                <Input
-                  id="confirmPassword"
-                  type="password"
-                  value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                  className="mt-1"
-                  placeholder="Confirm your password"
-                />
-                {confirmPassword && password !== confirmPassword && (
-                  <p className="mt-1 text-sm text-red-600">
-                    Passwords do not match
-                  </p>
-                )}
-              </div>
-            </div>
+            <Alert className="mb-6">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                Please log in with the invited email to accept this invitation.
+              </AlertDescription>
+            </Alert>
           )}
 
           <form onSubmit={handleSubmit}>
             <Button
               type="submit"
               className="w-full"
-              disabled={
-                acceptMutation.isPending ||
-                invitation.emailMismatch ||
-                (!isLoggedIn &&
-                  !invitation.userExists &&
-                  passwordErrors.length > 0)
-              }
+              disabled={acceptMutation.isPending || emailMismatch}
             >
               {acceptMutation.isPending ? (
                 <>
                   <Loader2 className="h-4 w-4 animate-spin mr-2" />
-                  {isLoggedIn
-                    ? "Joining organization..."
-                    : invitation.userExists
-                    ? "Joining organization..."
-                    : "Creating account..."}
+                  {isLoggedIn ? "Joining organization..." : "Redirecting to login..."}
                 </>
               ) : isLoggedIn ? (
                 "Join Organization"
               ) : (
-                "Accept Invitation"
+                "Log in to Accept"
               )}
             </Button>
           </form>


### PR DESCRIPTION
- Backend now exposes GET /connect for Instagram and YouTube.
- App already uses GET /social-accounts/youtube/connect.
- Note: other platforms still call /direct-auth in the app; align to /connect in a follow-up once server routes are enabled.
- Organization management IN PROGRESS