### PR TITLE
feat(app): align dashboard + scheduled page to true scheduled posts

### DIFF
--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -31,7 +31,7 @@ import {
   getTextColor,
 } from "../../lib/utils";
 import { useNavigate, Link } from "react-router-dom";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useAuth } from "../../store/hooks";
 import { useQuery } from "@tanstack/react-query";
 import { Badge, StatusBadge, BadgeGroup } from "../ui/badge";
@@ -64,8 +64,14 @@ export default function DashboardPage() {
     staleTime: 10_000,
   }) as { data: { items: any[] } };
 
+  const upcomingFrom = useMemo(() => new Date().toISOString(), []);
   const { data: upcomingResp } = useQuery({
-    queryKey: ["/social-posts?status=scheduled&limit=3"],
+    // Use v2 scheduled-posts with active scheduled filter and time window
+    queryKey: [
+      `/scheduled-posts?mode=scheduled&status=pending&from=${encodeURIComponent(
+        upcomingFrom
+      )}&limit=3&order=scheduledAsc`,
+    ],
     enabled: isAuthenticated,
     staleTime: 10_000,
   }) as { data: { items: any[] } };
@@ -77,7 +83,7 @@ export default function DashboardPage() {
   }) as { data: { items: any[] } };
 
   const recentPosts = recentPostsResp?.items || [];
-  const recentScheduledPosts = upcomingResp?.items || [];
+  const recentScheduledPosts = (upcomingResp?.items || []).slice(0, 3);
   const socialAccounts = socialAccountsResp?.items || [];
 
   if (authLoading) {

--- a/src/components/posts/scheduled-posts/ScheduledPosts.tsx
+++ b/src/components/posts/scheduled-posts/ScheduledPosts.tsx
@@ -52,17 +52,13 @@ export default function ScheduledPosts() {
   }, [selectedDate]);
 
   // Get posts
-  const {
-    data: scheduledResp,
-    isLoading: isFetchingScheduledPosts,
-  } = useQuery({
-    // Organization-scoped v2 endpoint; axios injects x-organization-id
-    queryKey: ["/scheduled-posts"],
-  }) as {
-    data:
-      | { items?: any[]; nextCursor?: string }
-      | { data?: any[] }
-      | undefined;
+  const { data: scheduledResp, isLoading: isFetchingScheduledPosts } = useQuery(
+    {
+      // Only show truly scheduled items
+      queryKey: ["/scheduled-posts?mode=scheduled"],
+    }
+  ) as {
+    data: { items?: any[]; nextCursor?: string } | { data?: any[] } | undefined;
     isLoading: boolean;
   };
 
@@ -260,7 +256,8 @@ export default function ScheduledPosts() {
                     selected={selectedDate}
                     onSelect={setSelectedDate}
                     modifiers={{
-                      hasPost: (date) => scheduleHasPostsForDate(new Date(date)),
+                      hasPost: (date) =>
+                        scheduleHasPostsForDate(new Date(date)),
                     }}
                     modifiersClassNames={{
                       // Small dot indicator for days that have posts


### PR DESCRIPTION
- Dashboard 'Upcoming':
  - Switch to /scheduled-posts?mode=scheduled&status=pending&from=<now>&order=scheduledAsc&limit=3.
  - Memoize 'from' param to avoid query key churn.
  - File: components/dashboard/index.tsx
- Scheduled page:
  - Query /scheduled-posts?mode=scheduled (excludes immediate).
  - File: components/posts/scheduled-posts/ScheduledPosts.tsx

Notes:
- Aligns UI with SSOT separation:
  - scheduled-posts = pending/future work.
  - social-posts = published history.