### PR TITLE
feat(app): PostFlow load draft on Continue + persist selected platfor…

### DIFF
--- a/src/api/postDrafts.ts
+++ b/src/api/postDrafts.ts
@@ -1,0 +1,95 @@
+import axiosInstance from "./axios";
+
+export type PlatformName =
+  | "twitter"
+  | "linkedin"
+  | "instagram"
+  | "threads"
+  | "tiktok"
+  | "youtube"
+  | "facebook";
+
+export type PostDraftMediaPayload = {
+  type: "image" | "video";
+  url?: string;
+  ref?: string;
+  width?: number;
+  height?: number;
+  durationSec?: number;
+};
+
+export type DraftTargetPayload = {
+  platform: PlatformName;
+  socialAccountId: string;
+  teamId?: string;
+};
+
+export type CreatePostDraftPayload = {
+  title?: string;
+  content: string;
+  media?: PostDraftMediaPayload[];
+  tags?: string[];
+  sourceContentId?: string;
+  platformCaptions?: Record<string, string>;
+  targets?: DraftTargetPayload[];
+};
+
+export type PromotePostDraftPayload = {
+  mode: "immediate" | "scheduled";
+  targets: Array<{
+    socialAccountId: string;
+    platform?: string;
+    teamId?: string;
+  }>;
+  scheduleAt?: string;
+  tiktokOptions?: Record<string, any>;
+  idempotencyKey?: string;
+  platformCaptions?: Record<string, string>;
+};
+
+export type PostDraftResponse = {
+  draft: any;
+};
+
+export type PromotePostDraftResponse = {
+  scheduledPostId?: string;
+  jobs?: string[];
+  mode: "immediate" | "scheduled";
+  draft: any;
+};
+
+const postDraftsApi = {
+  async list(params?: { status?: string; q?: string }) {
+    const response = await axiosInstance.get("/post-drafts", { params });
+    return response.data;
+  },
+
+  async get(id: string) {
+    const response = await axiosInstance.get(`/post-drafts/${id}`);
+    return response.data as PostDraftResponse;
+  },
+
+  async create(payload: CreatePostDraftPayload) {
+    const response = await axiosInstance.post(`/post-drafts`, payload);
+    return response.data as PostDraftResponse;
+  },
+
+  async update(id: string, payload: Partial<CreatePostDraftPayload>) {
+    const response = await axiosInstance.patch(`/post-drafts/${id}`, payload);
+    return response.data as PostDraftResponse;
+  },
+
+  async archive(id: string) {
+    await axiosInstance.delete(`/post-drafts/${id}`);
+  },
+
+  async promote(id: string, payload: PromotePostDraftPayload) {
+    const response = await axiosInstance.post(
+      `/post-drafts/${id}/promote`,
+      payload
+    );
+    return response.data as PromotePostDraftResponse;
+  },
+};
+
+export default postDraftsApi;

--- a/src/components/posts/drafts/DraftDetail.tsx
+++ b/src/components/posts/drafts/DraftDetail.tsx
@@ -1,0 +1,306 @@
+import { useMemo } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../../ui/card";
+import { Button } from "../../ui/button";
+import { Badge } from "../../ui/badge";
+import { Separator } from "../../ui/separator";
+import { ScrollArea } from "../../ui/scroll-area";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../../ui/table";
+import { Loader2, ArrowLeft, RefreshCw } from "lucide-react";
+import { format } from "date-fns";
+
+const formatDate = (value?: string | Date) => {
+  if (!value) return "—";
+  try {
+    return format(new Date(value), "PPP p");
+  } catch (err) {
+    return String(value);
+  }
+};
+
+const DraftDetail = () => {
+  const { draftId } = useParams<{ draftId: string }>();
+  const navigate = useNavigate();
+
+  const {
+    data,
+    isLoading,
+    isRefetching,
+    refetch,
+    error,
+  } = useQuery({
+    queryKey: draftId ? [`/post-drafts/${draftId}`] : [],
+    enabled: Boolean(draftId),
+  });
+
+  const draft = (data as any)?.draft;
+
+  const currentRevision = draft?.currentRevision ?? {};
+  const mediaItems: Array<{
+    type: "image" | "video";
+    url?: string;
+    ref?: string;
+  }> = Array.isArray(currentRevision.media) ? currentRevision.media : [];
+  const platformCaptions: Record<string, string> =
+    draft?.platformCaptions || currentRevision.platformCaptions || {};
+
+  const revisions = useMemo(() => {
+    const items = Array.isArray(draft?.revisions) ? draft.revisions : [];
+    return items
+      .slice()
+      .sort((a: any, b: any) => (b.revision ?? 0) - (a.revision ?? 0));
+  }, [draft]);
+
+  if (!draftId) {
+    return (
+      <div className="p-6 space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Draft not found</CardTitle>
+            <CardDescription>No draft identifier was provided.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button onClick={() => navigate(-1)}>
+              <ArrowLeft className="mr-2 h-4 w-4" /> Go back
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="h-6 w-6 animate-spin" />
+        <span className="ml-2 text-sm text-muted-foreground">
+          Loading draft...
+        </span>
+      </div>
+    );
+  }
+
+  if (error || !draft) {
+    return (
+      <div className="p-6 space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Unable to load draft</CardTitle>
+            <CardDescription>
+              {(error as Error)?.message ||
+                "The requested draft could not be found."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex items-center gap-2">
+            <Button onClick={() => navigate(-1)} variant="outline">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back
+            </Button>
+            <Button onClick={() => refetch()}>
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Retry
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <Button
+            variant="outline"
+            onClick={() => navigate(-1)}
+            className="mb-4"
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" /> Back
+          </Button>
+          <div className="flex items-center gap-3">
+            <h1 className="text-3xl font-bold tracking-tight">
+              {draft.title || "Untitled Draft"}
+            </h1>
+            <Badge variant="outline" className="uppercase">
+              {draft.status}
+            </Badge>
+            {isRefetching && (
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+            )}
+          </div>
+          <p className="text-sm text-muted-foreground mt-2">
+            Created {formatDate(draft.createdAt)} • Updated {formatDate(draft.updatedAt)}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" onClick={() => refetch()}>
+            <RefreshCw className="mr-2 h-4 w-4" /> Refresh
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card className="h-full">
+          <CardHeader>
+            <CardTitle>Current Content</CardTitle>
+            <CardDescription>
+              Latest revision ({currentRevision.revision ?? 0})
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <p className="font-semibold text-sm text-muted-foreground mb-1">
+                Body
+              </p>
+              <ScrollArea className="max-h-48 rounded border p-3">
+                <p className="whitespace-pre-wrap text-sm leading-6">
+                  {currentRevision.content || "No content"}
+                </p>
+              </ScrollArea>
+            </div>
+
+            <Separator />
+
+            <div>
+              <p className="font-semibold text-sm text-muted-foreground mb-2">
+                Platform Captions
+              </p>
+              {Object.keys(platformCaptions).length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No overrides set. Platforms will use the main caption.
+                </p>
+              ) : (
+                <ul className="space-y-2 text-sm">
+                  {Object.entries(platformCaptions).map(([platform, caption]) => (
+                    <li key={platform} className="border rounded p-2">
+                      <span className="font-semibold uppercase text-xs text-muted-foreground">
+                        {platform}
+                      </span>
+                      <p className="mt-1 whitespace-pre-wrap leading-6">
+                        {caption}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="h-full">
+          <CardHeader>
+            <CardTitle>Media</CardTitle>
+            <CardDescription>
+              {mediaItems.length > 0
+                ? `${mediaItems.length} attachment${
+                    mediaItems.length === 1 ? "" : "s"
+                  }`
+                : "No media attached"}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {mediaItems.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                Add media in the composer to include images or video.
+              </p>
+            ) : (
+              <div className="grid gap-4 sm:grid-cols-2">
+                {mediaItems.map((item, idx) => (
+                  <div
+                    key={`${item.ref || item.url || idx}-${idx}`}
+                    className="rounded border overflow-hidden"
+                  >
+                    {item.type === "video" ? (
+                      <video
+                        src={item.url}
+                        controls
+                        className="w-full aspect-video bg-black"
+                      />
+                    ) : (
+                      <img
+                        src={item.url}
+                        alt={`Draft media ${idx + 1}`}
+                        className="w-full h-full object-cover"
+                      />
+                    )}
+                    <div className="px-3 py-2 text-xs text-muted-foreground flex justify-between">
+                      <span className="uppercase">{item.type}</span>
+                      {item.ref && <span className="truncate">{item.ref}</span>}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Revision History</CardTitle>
+          <CardDescription>
+            All saved revisions appear in descending order.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {revisions.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No revisions yet.</p>
+          ) : (
+            <ScrollArea className="max-h-72">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-24">Revision</TableHead>
+                    <TableHead>Updated By</TableHead>
+                    <TableHead>Updated At</TableHead>
+                    <TableHead>Content Preview</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {revisions.map((rev: any) => (
+                    <TableRow key={rev.revision}>
+                      <TableCell>
+                        <Badge
+                          variant={
+                            rev.revision === currentRevision.revision
+                              ? "default"
+                              : "outline"
+                          }
+                        >
+                          {rev.revision}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>{rev.updatedBy || "—"}</TableCell>
+                      <TableCell>{formatDate(rev.updatedAt)}</TableCell>
+                      <TableCell>
+                        <p className="text-sm max-w-md truncate">
+                          {rev.content || "(empty)"}
+                        </p>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </ScrollArea>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default DraftDetail;

--- a/src/components/posts/drafts/DraftsList.tsx
+++ b/src/components/posts/drafts/DraftsList.tsx
@@ -1,0 +1,243 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../../ui/card";
+import { Button } from "../../ui/button";
+import { Badge } from "../../ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../../ui/table";
+import { ScrollArea } from "../../ui/scroll-area";
+import { Loader2, FileText, Plus } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { cn } from "../../../lib/utils";
+
+const STATUS_FILTERS = [
+  "all",
+  "draft",
+  "ready",
+  "scheduled",
+  "archived",
+] as const;
+
+type StatusFilter = (typeof STATUS_FILTERS)[number];
+
+const DraftsList = () => {
+  const [status, setStatus] = useState<StatusFilter>("all");
+  const navigate = useNavigate();
+
+  const queryKey = useMemo(() => {
+    if (status === "all") return "/post-drafts";
+    return `/post-drafts?status=${status}`;
+  }, [status]);
+
+  const { data, isLoading, isRefetching, refetch, error } = useQuery({
+    queryKey: [queryKey],
+  });
+
+  const drafts: any[] =
+    ((data as any)?.items as any[]) || ((data as any)?.data as any[]) || [];
+
+  const handleCreatePost = () => navigate("/dashboard/post-flow");
+
+  const handleViewDraft = (id: string) => navigate(`/dashboard/drafts/${id}`);
+
+  const handleContinueDraft = (id: string) =>
+    navigate(`/dashboard/post-flow?draftId=${id}`);
+
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <div className="flex items-center justify-center h-48">
+          <Loader2 className="h-6 w-6 animate-spin" />
+          <span className="ml-2 text-sm text-muted-foreground">
+            Loading drafts...
+          </span>
+        </div>
+      );
+    }
+
+    if (error) {
+      return (
+        <div className="flex flex-col items-center justify-center h-48 space-y-4">
+          <p className="text-sm text-muted-foreground">
+            {(error as Error)?.message || "Unable to load drafts."}
+          </p>
+          <Button onClick={() => refetch()}>Try again</Button>
+        </div>
+      );
+    }
+
+    if (!drafts.length) {
+      return (
+        <div className="flex flex-col items-center justify-center h-48 space-y-4 text-center">
+          <FileText className="h-10 w-10 text-muted-foreground" />
+          <div>
+            <p className="font-semibold">No drafts found</p>
+            <p className="text-sm text-muted-foreground">
+              Save a draft from the composer or adjust your filters.
+            </p>
+          </div>
+          <Button onClick={handleCreatePost}>
+            <Plus className="mr-2 h-4 w-4" /> Create new post
+          </Button>
+        </div>
+      );
+    }
+
+    return (
+      <ScrollArea className="max-h-[60vh]">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[45%]">Draft</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Updated</TableHead>
+              <TableHead>Platforms</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {drafts.map((draft: any) => {
+              const updated = draft.updatedAt
+                ? formatDistanceToNow(new Date(draft.updatedAt), {
+                    addSuffix: true,
+                  })
+                : "—";
+              const captionCount = draft.platformCaptions
+                ? Object.keys(draft.platformCaptions).length
+                : 0;
+              return (
+                <TableRow key={draft._id}>
+                  <TableCell>
+                    <div className="space-y-1">
+                      <p className="font-medium">
+                        {draft.title || "Untitled draft"}
+                      </p>
+                      <p className="text-sm text-muted-foreground line-clamp-2">
+                        {draft.currentRevision?.content || "No content"}
+                      </p>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="outline" className="uppercase">
+                      {draft.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <p className="text-sm">{updated}</p>
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex flex-wrap gap-2">
+                      {captionCount > 0 ? (
+                        Object.keys(draft.platformCaptions || {}).map(
+                          (platform) => (
+                            <Badge
+                              key={platform}
+                              variant="secondary"
+                              className="uppercase"
+                            >
+                              {platform}
+                            </Badge>
+                          )
+                        )
+                      ) : (
+                        <span className="text-sm text-muted-foreground">
+                          Using main caption
+                        </span>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-right space-x-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleViewDraft(draft._id)}
+                    >
+                      View
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleContinueDraft(draft._id)}
+                    >
+                      Continue
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </ScrollArea>
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Drafts</h1>
+          <p className="text-sm text-muted-foreground">
+            Manage saved drafts and continue where you left off.
+          </p>
+        </div>
+        <Button onClick={handleCreatePost}>
+          <Plus className="mr-2 h-4 w-4" />
+          New Post
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader className="space-y-1">
+          <CardTitle>Saved drafts</CardTitle>
+          <CardDescription>
+            {isRefetching
+              ? "Refreshing..."
+              : `${drafts.length} draft${drafts.length === 1 ? "" : "s"}`}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-wrap gap-2">
+            {STATUS_FILTERS.map((filter) => (
+              <Button
+                key={filter}
+                variant={status === filter ? "default" : "outline"}
+                size="sm"
+                onClick={() => setStatus(filter)}
+                className="capitalize"
+              >
+                {filter === "all" ? "All" : filter}
+              </Button>
+            ))}
+            <div className="flex-1" />
+            <Button variant="ghost" size="sm" onClick={() => refetch()}>
+              <Loader2
+                className={cn(
+                  "mr-2 h-4 w-4",
+                  isRefetching ? "animate-spin" : "opacity-60"
+                )}
+              />
+              Refresh
+            </Button>
+          </div>
+
+          {renderContent()}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default DraftsList;

--- a/src/components/posts/post-flow/MediaUpload.tsx
+++ b/src/components/posts/post-flow/MediaUpload.tsx
@@ -51,7 +51,7 @@ import {
 export interface MediaItem {
   id: string;
   url: string; // This might be a local URL (blob) initially, then Cloudinary URL
-  file: File; // The actual file object
+  file?: File; // The actual file object when available
   type: "image" | "video";
   thumbnailTime?: number;
   thumbnailUrl?: string;
@@ -59,6 +59,10 @@ export interface MediaItem {
   uploadProgress?: number;
   error?: string;
   processedUrl?: string; // URL after backend processing
+  width?: number;
+  height?: number;
+  durationSec?: number;
+  ref?: string;
 }
 
 // Define or extend MediaUploadProps here for clarity, assuming it's not strictly from mediaUploadComponents.tsx for now

--- a/src/components/posts/post-flow/mediaUploadComponents.tsx
+++ b/src/components/posts/post-flow/mediaUploadComponents.tsx
@@ -19,6 +19,10 @@ export function MediaItemDisplayContent({
   readonly index: number;
   readonly isCover: boolean;
 }) {
+  const previewSrc =
+    item.type === "video"
+      ? item.thumbnailUrl ?? item.url
+      : item.url;
   return (
     <>
       <div className="absolute inset-0 bg-black/60 flex items-center justify-center pointer-events-none">
@@ -30,7 +34,7 @@ export function MediaItemDisplayContent({
           />
         ) : (
           <img
-            src={item.thumbnailUrl ?? ""} // Provide a fallback empty string for thumbnailUrl
+            src={previewSrc || ""} // Provide a fallback preview source for video items
             alt={`Media ${index + 1}`}
             className="w-full h-full object-cover"
           />

--- a/src/config/breadcrumbRoutes.tsx
+++ b/src/config/breadcrumbRoutes.tsx
@@ -98,6 +98,52 @@ export const breadcrumbRoutes: BreadcrumbRoute[] = [
     ],
   },
 
+  {
+    pattern: /^\/dashboard\/drafts\/([^\/]+)$/,
+    segments: [
+      {
+        label: "Dashboard",
+        href: "/dashboard",
+        icon: <Home className="w-4 h-4" />,
+      },
+      {
+        label: "Drafts",
+        href: "/dashboard/drafts",
+        icon: <FileText className="w-4 h-4" />,
+      },
+      {
+        label: "Create Post",
+        href: "/dashboard/post-flow",
+        icon: <Plus className="w-4 h-4" />,
+      },
+      {
+        label: (data) => {
+          if (!data) return "Draft";
+          return (
+            data?.draft?.title || data?.title || "Draft"
+          );
+        },
+        queryKey: (params) => [`/post-drafts/${params[0]}`],
+        fallback: (id) => `Draft ${id.slice(0, 8)}...`,
+        icon: <FileText className="w-4 h-4" />,
+      },
+    ],
+  },
+  {
+    pattern: /^\/dashboard\/drafts$/,
+    segments: [
+      {
+        label: "Dashboard",
+        href: "/dashboard",
+        icon: <Home className="w-4 h-4" />,
+      },
+      {
+        label: "Drafts",
+        icon: <FileText className="w-4 h-4" />,
+      },
+    ],
+  },
+
   // Help articles: /dashboard/help/:articleId or any help sub-routes
   {
     pattern: /^\/dashboard\/help\/([^\/]+)$/,

--- a/src/layouts/DashboardSidebar.tsx
+++ b/src/layouts/DashboardSidebar.tsx
@@ -16,6 +16,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Building,
+  FileText,
 } from "lucide-react";
 import { useAuth } from "../store/hooks";
 import { useMemo } from "react";
@@ -109,6 +110,13 @@ export default function DashboardSidebar({
         badge: !hasValidSub ? "Team" : null,
         premium: true,
         show: true, // Show but may be disabled
+      },
+      {
+        icon: <FileText size={18} />,
+        label: "Drafts",
+        href: "/dashboard/drafts",
+        badge: null,
+        show: true,
       },
       {
         icon: <Folder size={18} />,

--- a/src/lib/mediaUtils.ts
+++ b/src/lib/mediaUtils.ts
@@ -102,6 +102,7 @@ export const updateVideoThumbnailTime = async (
   if (itemIndex === -1 || media[itemIndex].type !== "video") return;
 
   const item = media[itemIndex];
+  if (!item.file) return;
   try {
     // For now, keep client-side thumbnail extraction for preview purposes
     const thumbnailUrl = await extractVideoThumbnail(item.file, time);

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -45,6 +45,12 @@ const ScheduledPosts = React.lazy(
 const PostFlow = React.lazy(
   () => import("../components/posts/post-flow/PostFlow")
 );
+const DraftsList = React.lazy(
+  () => import("../components/posts/drafts/DraftsList")
+);
+const DraftDetail = React.lazy(
+  () => import("../components/posts/drafts/DraftDetail")
+);
 const Billing = React.lazy(() => import("../components/billing"));
 const HelpSupport = React.lazy(() => import("../components/help-support"));
 const PostCreate = React.lazy(
@@ -141,6 +147,8 @@ const AppRoutes = () => {
                 <Route path="post-flow" element={<PostFlow />} />
                 <Route path="posts" element={<Posts />} />
                 <Route path="scheduled" element={<ScheduledPosts />} />
+                <Route path="drafts" element={<DraftsList />} />
+                <Route path="drafts/:draftId" element={<DraftDetail />} />
                 <Route path="settings" element={<UserSettings />} />
                 <Route path="billing" element={<Billing />} />
                 <Route path="help" element={<HelpSupport />} />


### PR DESCRIPTION
…ms/accounts

- Draft loading:
  - Accept draftId via query param.
  - Fetch draft on mount + hydrate caption, platformCaptions, media, and selected account targets.
  - Reset state cleanly when draftId changes.
  - Surface load errors via toast.
- Save draft:
  - Include targets built from selectedAccounts (platform normalized; 'x' → 'twitter'; include teamId when available).
  - Persist caption, platformCaptions, and media.
- Media handling:
  - Allow rendering stored items without File (make file optional).
  - Carry width/height/durationSec/ref.
  - Use video thumbnail fallback to URL.
  - Guard client-side thumbnail extraction when file is absent.
- Hook changes:
  - Accept initialDraftId to track current draft.
  - Reuse stored media metadata; only upload when blobs are present.
  - Compute idempotency key unchanged for publish paths.
- Types:
  - Add PlatformName and DraftTargetPayload to postDrafts client.
  - Extend promote targets with optional teamId.