### PR TITLE
feat(app): PostFlow draft continuation + persist targets; profile set…

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,6 +1,13 @@
 import axiosInstance from "./axios";
 import { User } from "../types";
 
+export type UpdateUserPayload = {
+  name?: string;
+  bio?: string | null;
+  avatarUrl?: string | null;
+  avatarPublicId?: string | null;
+};
+
 interface InviteUserRequest {
   email: string;
   firstName: string;
@@ -21,17 +28,12 @@ export const usersApi = {
     await axiosInstance.post("/invitations", data);
   },
 
-  updateUser: async (updates: FormData | Partial<User>): Promise<User> => {
-    try {
-      const response = await axiosInstance.patch(`/users/me/`, updates, {
-        headers: {
-          "Content-Type": "multipart/form-data",
-        },
-      });
-      return response.data;
-    } catch (error: any) {
-      return error;
-    }
+  updateUser: async (updates: UpdateUserPayload): Promise<User> => {
+    const payload = Object.fromEntries(
+      Object.entries(updates).filter(([, value]) => value !== undefined)
+    ) as UpdateUserPayload;
+    const response = await axiosInstance.patch(`/users/me`, payload);
+    return (response.data as { user: User }).user;
   },
 
   deleteUser: async (userId: string): Promise<void> => {

--- a/src/components/auth/ForgotPasswordForm.tsx
+++ b/src/components/auth/ForgotPasswordForm.tsx
@@ -8,13 +8,12 @@ import {
   FormControl,
   FormField,
   FormItem,
-  FormMessage,
 } from "../../components/ui/form";
 import { Input } from "../../components/ui/input";
 import { Button } from "../../components/ui/button";
 import { apiRequest } from "../../lib/queryClient";
 import { useMutation } from "@tanstack/react-query";
-import { Mail, ArrowLeft, Send, CheckCircle, AlertCircle } from "lucide-react";
+import { Mail, ArrowLeft, Send, CheckCircle } from "lucide-react";
 
 const forgotPasswordSchema = z.object({
   email: z.string().email("Please enter a valid email"),
@@ -77,7 +76,6 @@ export default function ForgotPasswordForm({
   if (isSubmitted) {
     return (
       <div className="text-center py-8 space-y-6 animate-in fade-in duration-500">
-        {/* Enhanced success icon with animation */}
         <div className="relative mx-auto w-20 h-20 mb-6">
           <div className="absolute inset-0 bg-gradient-to-r from-green-400 to-green-600 rounded-full opacity-20 animate-pulse"></div>
           <div className="relative flex items-center justify-center w-20 h-20 bg-gradient-to-r from-green-400 to-green-600 rounded-full">
@@ -85,7 +83,6 @@ export default function ForgotPasswordForm({
           </div>
         </div>
 
-        {/* Enhanced success message */}
         <div className="space-y-3">
           <h3 className="text-2xl font-bold bg-gradient-to-r from-gray-900 to-gray-700 dark:from-white dark:to-gray-300 bg-clip-text text-transparent">
             Check your email
@@ -99,7 +96,6 @@ export default function ForgotPasswordForm({
           </p>
         </div>
 
-        {/* Enhanced action buttons */}
         <div className="space-y-3">
           <Button
             variant="gradient"
@@ -123,7 +119,6 @@ export default function ForgotPasswordForm({
 
   return (
     <div className="space-y-6">
-      {/* Enhanced header section */}
       <div className="text-center space-y-3">
         <div className="mx-auto w-12 h-12 bg-gradient-to-r from-primary-500 to-primary-600 rounded-full flex items-center justify-center">
           <Mail className="w-6 h-6 text-white" />
@@ -139,7 +134,6 @@ export default function ForgotPasswordForm({
 
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
-          {/* Enhanced email field */}
           <FormField
             control={form.control}
             name="email"
@@ -157,17 +151,10 @@ export default function ForgotPasswordForm({
                     {...field}
                   />
                 </FormControl>
-                {fieldState.error && (
-                  <FormMessage className="flex items-center gap-2 mt-2">
-                    <AlertCircle className="w-4 h-4" />
-                    {fieldState.error.message}
-                  </FormMessage>
-                )}
               </FormItem>
             )}
           />
 
-          {/* Enhanced action buttons */}
           <div className="space-y-4 pt-2">
             <Button
               type="submit"
@@ -183,23 +170,10 @@ export default function ForgotPasswordForm({
                 {isLoading ? "Sending..." : "Send Reset Link"}
               </span>
             </Button>
-
-            <Button
-              type="button"
-              variant="ghost"
-              className="w-full font-medium hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors duration-200"
-              onClick={onBack}
-            >
-              <span className="flex items-center justify-center gap-2">
-                <ArrowLeft className="w-4 h-4" />
-                Back to login
-              </span>
-            </Button>
           </div>
         </form>
       </Form>
 
-      {/* Enhanced help text */}
       <div className="text-center">
         <p className="text-xs text-gray-500 dark:text-gray-500 max-w-xs mx-auto leading-relaxed">
           Remember your password?{" "}

--- a/src/components/posts/drafts/DraftsList.tsx
+++ b/src/components/posts/drafts/DraftsList.tsx
@@ -18,7 +18,7 @@ import {
   TableHeader,
   TableRow,
 } from "../../ui/table";
-import { ScrollArea } from "../../ui/scroll-area";
+import { ScrollArea, ScrollBar } from "../../ui/scroll-area";
 import { Loader2, FileText, Plus } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 import { cn } from "../../../lib/utils";
@@ -97,7 +97,7 @@ const DraftsList = () => {
     }
 
     return (
-      <ScrollArea className="max-h-[60vh]">
+      <ScrollArea className="h-[60vh] w-full pr-4">
         <Table>
           <TableHeader>
             <TableRow>
@@ -180,6 +180,7 @@ const DraftsList = () => {
             })}
           </TableBody>
         </Table>
+        <ScrollBar orientation="vertical" />
       </ScrollArea>
     );
   };

--- a/src/components/settings/ProfileInformation.tsx
+++ b/src/components/settings/ProfileInformation.tsx
@@ -59,34 +59,26 @@ const ProfileInformation = ({
     fileInputRef.current?.click();
   };
 
-  const handleFormSubmit = (formData: any) => {
-    console.log("Form data received:", formData);
-
+  const handleFormSubmit = async (formData: any) => {
     const submitData = new FormData();
 
     // Only add the specific fields we want
-    if (formData.firstName) {
-      submitData.append("firstName", formData.firstName);
-    }
-    if (formData.lastName) {
-      submitData.append("lastName", formData.lastName);
+    if (formData.name) {
+      submitData.append("name", formData.name);
     }
     if (formData.bio) {
       submitData.append("bio", formData.bio);
     }
+    if (formData.avatar) {
+      submitData.append("avatar", formData.avatar);
+    }
 
     // Add avatar file if selected
     if (selectedFile) {
-      console.log("Adding avatar file:", selectedFile.name);
       submitData.append("avatar", selectedFile);
     }
 
-    // Debug: Log what we're sending
-    for (let [key, value] of submitData.entries()) {
-      console.log("FormData entry:", key, value);
-    }
-
-    onProfileSubmit(submitData);
+    await onProfileSubmit(submitData);
   };
   return (
     <Card className="relative overflow-hidden bg-gradient-to-br from-background to-muted/30 border-border/50">
@@ -177,12 +169,12 @@ const ProfileInformation = ({
               <div className="flex-1 space-y-4">
                 <FormField
                   control={profileForm.control}
-                  name="firstName"
+                  name="name"
                   render={({ field }) => (
                     <FormItem>
                       <FormLabel className="flex items-center gap-2 text-sm font-medium">
                         <User className="h-4 w-4 text-primary" />
-                        First Name
+                        Name
                       </FormLabel>
                       <FormControl>
                         <div className="relative">
@@ -204,7 +196,7 @@ const ProfileInformation = ({
                   )}
                 />
 
-                <FormField
+                {/* <FormField
                   control={profileForm.control}
                   name="lastName"
                   render={({ field }) => (
@@ -231,7 +223,7 @@ const ProfileInformation = ({
                       <FormMessage />
                     </FormItem>
                   )}
-                />
+                /> */}
 
                 <FormField
                   control={profileForm.control}

--- a/src/layouts/DashboardHeader.tsx
+++ b/src/layouts/DashboardHeader.tsx
@@ -28,8 +28,8 @@ import { Badge } from "../components/ui/badge";
 import { useDynamicBreadcrumbs } from "../hooks/useDynamicBreadcrumbs";
 
 export default function DashboardHeader() {
-  const { user, logout, canManageBilling } = useAuth();
-  const { canConnectSocialAccounts } = useAccessControl();
+  const { user, logout, canManageBilling, subscriptionInfo } = useAuth();
+  const { canConnectSocialAccounts, hasValidSubscription } = useAccessControl();
   const location = useLocation();
 
   const mobileMenuOpen = useMobileMenuStore(
@@ -109,11 +109,11 @@ export default function DashboardHeader() {
                 <Avatar className="h-9 w-9">
                   <AvatarImage
                     src={user?.avatar ?? ""}
-                    alt={user?.firstName ?? ""}
+                    alt={user?.name ?? ""}
                   />
                   <AvatarFallback className="bg-primary-100 text-primary-700 dark:bg-primary-900 dark:text-primary-300">
-                    {user?.firstName
-                      ? getInitials(`${user.firstName} ${user.lastName || ""}`)
+                    {user?.name
+                      ? getInitials(`${user.name}`)
                       : user?.username?.substring(0, 2).toUpperCase()}
                   </AvatarFallback>
                 </Avatar>
@@ -123,18 +123,12 @@ export default function DashboardHeader() {
               <DropdownMenuLabel>
                 <div className="flex flex-col space-y-1">
                   <p className="font-medium">
-                    {user?.firstName
-                      ? `${user.firstName} ${user.lastName || ""}`.trim()
-                      : user?.username}
+                    {user?.name ? `${user.name}` : user?.username}
                   </p>
                   <p className="text-xs text-muted-foreground">{user?.email}</p>
-                  {user?.billing?.paymentStatus && (
-                    <Badge variant="outline" className="text-xs w-fit">
-                      {user.billing.paymentStatus === "active"
-                        ? "Team Plan"
-                        : "Free Plan"}
-                    </Badge>
-                  )}
+                  <Badge variant="outline" className="text-xs w-fit capitalize">
+                    {subscriptionInfo?.subscriptionTier || "Free "} Plan
+                  </Badge>
                 </div>
               </DropdownMenuLabel>
               <DropdownMenuSeparator />

--- a/src/pages/forgot-password.tsx
+++ b/src/pages/forgot-password.tsx
@@ -27,15 +27,6 @@ export default function ForgotPasswordPage() {
       <div className="w-full max-w-md bg-white dark:bg-gray-800 rounded-xl shadow-md p-8">
         <ForgotPasswordForm onBack={() => navigate("/login")} />
       </div>
-
-      <p className="mt-6 text-center text-sm">
-        Remember your password?{" "}
-        <Link to="/login">
-          <span className="text-primary-600 dark:text-primary-400 hover:underline">
-            Log in
-          </span>
-        </Link>
-      </p>
     </div>
   );
 }

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -454,10 +454,10 @@ export const useAuthStore = create<AuthState>()(
             // Enhanced authentication context
             userRole,
             userType,
-            subscriptionInfo: data.subscriptionInfo,
+            // subscriptionInfo: data.subscriptionInfo,
 
             // Use backend-computed permissions directly (single source of truth)
-            ...data.computedPermissions,
+            // ...data.computedPermissions,
           });
         } catch (error: any) {
           set({ error: error.message, isLoading: false });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -75,6 +75,8 @@ export interface User {
     | "canceled"
     | "expired"
     | "none";
+  bio?: string | null;
+  avatarPublicId?: string | null;
 }
 
 export interface AuthState {


### PR DESCRIPTION
…tings wired to /users/me

Draft continuation:
- Read draftId from query; fetch via API; hydrate composer with:
  - global caption, platformCaptions, media (url/ref, file optional), and selected accounts from draft.targets/currentRevision.targets.
- Guard initialization to avoid re-running.
- Toast on fetch errors.

Draft persistence:
- Extend draft save payload to include selected targets built from current selection.
- Normalize 'x'→'twitter'; include teamId when present.
- Update postDrafts client types: PlatformName, DraftTargetPayload, teamId support.

Hooks:
- usePostSubmission:
  - Accept initialDraftId, retain currentDraftId.
  - Reuse media metadata, only upload blobs when present.
  - Compute platform-target idempotency unchanged.
  - Build SSOT media from existing fields when File not available.

Media:
- Make MediaItem.file optional.
- Add width/height/durationSec/ref.
- Ensure video preview falls back to url.
- Skip thumbnail extraction when no File.

Drafts list UX:
- Keep card height, make inner list scrollable.
- Add h-[60vh] ScrollArea with explicit ScrollBar.

Settings/Profile:
- Implement avatar upload via Cloudinary signature endpoint.
- PATCH /users/me with { name, bio|null, avatarUrl, avatarPublicId }.
- Switch usersApi.updateUser to JSON payload, return { user }.
- Await onProfileSubmit; don't attempt email changes.
- Extend User type with bio and avatarPublicId.